### PR TITLE
Add delegated identity signing support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
             dependencies: [
                 "Candid",
                 "BigInt",
+                .product(name: "PotentCodables", package: "PotentCodables"),
                 .product(name: "secp256k1", package: "secp256k1.swift"),
 //                .target(name: "bls12381"),
             ]

--- a/README.md
+++ b/README.md
@@ -448,6 +448,23 @@ class SimpleSigningPrincipal: ICPSigningPrincipal {
 }
 ```
 
+### Delegated Identity
+
+`ICPDelegatedIdentity` represents an identity that has been delegated authority to authenticate and sign as a different principal. It validates the delegation chain on initialization and ensures the chain ultimately matches the signing `ICPSigningPrincipal`.
+
+- `fromPublicKeyDer` is the DER-encoded public key of the delegated-from principal.
+- `chain` is an ordered array of `ICPSignedDelegation` from `fromPublicKeyDer` to `to`.
+- Actual signing is performed by `to`, so `ICPDelegatedIdentity.sign(...)` forwards to `to.sign(...)`.
+- Use `unchecked(...)` to skip validation only when the chain is already trusted.
+
+```swift
+let delegated = try ICPDelegatedIdentity(
+  fromPublicKeyDer: fromDer,
+  to: signingIdentity,
+  chain: signedDelegations
+)
+```
+
 ## Known Limitations
 
 - Serialisation of recursive candid values leads to infinite loop.

--- a/Sources/IcpKit/Cryptography/EllipticSign.swift
+++ b/Sources/IcpKit/Cryptography/EllipticSign.swift
@@ -29,6 +29,11 @@ extension ICPCryptography {
 /// https://github.com/horizontalsystems/HsCryptoKit.Swift/blob/main/Sources/HsCryptoKit/EllipticCurveEncrypterSecp256k1.swift
 import secp256k1
 
+enum Secp256k1VerifyError: Error {
+    case invalidPublicKey
+    case invalidSignature
+}
+
 /// Convenience class over libsecp256k1 methods
 private final class EllipticCurveEncrypterSecp256k1 {
     // holds internal state of the c library
@@ -122,4 +127,49 @@ private final class EllipticCurveEncrypterSecp256k1 {
         return output
     }
     
+}
+
+public extension ICPCryptography {
+    static func verifySecp256k1(signatureDER: Data, message: Data, publicKeyUncompressed: Data) throws -> Bool {
+        let context = secp256k1.Context.raw
+        var pubKey = secp256k1_pubkey()
+        let pubKeyResult = publicKeyUncompressed.withUnsafeBytes { buffer -> Int32 in
+            guard let baseAddress = buffer.baseAddress else { return 0 }
+            return secp256k1_ec_pubkey_parse(
+                context,
+                &pubKey,
+                baseAddress.assumingMemoryBound(to: UInt8.self),
+                publicKeyUncompressed.count
+            )
+        }
+        guard pubKeyResult == 1 else {
+            throw Secp256k1VerifyError.invalidPublicKey
+        }
+
+        var signature = secp256k1_ecdsa_signature()
+        let signatureResult = signatureDER.withUnsafeBytes { buffer -> Int32 in
+            guard let baseAddress = buffer.baseAddress else { return 0 }
+            return secp256k1_ecdsa_signature_parse_der(
+                context,
+                &signature,
+                baseAddress.assumingMemoryBound(to: UInt8.self),
+                signatureDER.count
+            )
+        }
+        guard signatureResult == 1 else {
+            throw Secp256k1VerifyError.invalidSignature
+        }
+
+        let hash = ICPCryptography.sha256(message)
+        let verifyResult = hash.withUnsafeBytes { buffer -> Int32 in
+            guard let baseAddress = buffer.baseAddress else { return 0 }
+            return secp256k1_ecdsa_verify(
+                context,
+                &signature,
+                baseAddress.assumingMemoryBound(to: UInt8.self),
+                &pubKey
+            )
+        }
+        return verifyResult == 1
+    }
 }

--- a/Sources/IcpKit/Cryptography/ICPCryptography+Principal.swift
+++ b/Sources/IcpKit/Cryptography/ICPCryptography+Principal.swift
@@ -16,4 +16,12 @@ public extension ICPCryptography {
         let bytes = hash + Data([0x02])
         return ICPPrincipal(bytes)
     }
+
+    /// Principal with Self-Authenticating ID from a DER-encoded public key.
+    /// These have the form H(der_public_key) · 0x02 (29 bytes).
+    static func selfAuthenticatingPrincipal(derPublicKey publicKey: Data) -> ICPPrincipal {
+        let hash = ICPCryptography.sha224(publicKey)
+        let bytes = hash + Data([0x02])
+        return ICPPrincipal(bytes)
+    }
 }

--- a/Sources/IcpKit/ICPRequest/ICPRequestBuilder.swift
+++ b/Sources/IcpKit/ICPRequest/ICPRequestBuilder.swift
@@ -46,11 +46,18 @@ public enum ICPRequestBuilder {
         }
         let requestId = try content.calculateRequestId()
         let senderSignature = try await sender.sign(requestId, domain: "ic-request")
-        let senderPublicKey = try ICPCryptography.der(uncompressedEcPublicKey: sender.rawPublicKey)
+        let senderPublicKey: Data
+        if let derProvider = sender as? ICPDerPublicKeyProvider {
+            senderPublicKey = derProvider.publicKeyDer
+        } else {
+            senderPublicKey = try ICPCryptography.der(uncompressedEcPublicKey: sender.rawPublicKey)
+        }
+        let senderDelegation = (sender as? ICPDelegationProvider)?.delegationChain
         return ICPRequestEnvelope(
             content: content,
             sender_pubkey: senderPublicKey,
-            sender_sig: senderSignature
+            sender_sig: senderSignature,
+            sender_delegation: senderDelegation
         )        
     }
     

--- a/Sources/IcpKit/ICPRequest/ICPRequestEnvelope.swift
+++ b/Sources/IcpKit/ICPRequest/ICPRequestEnvelope.swift
@@ -10,21 +10,24 @@ public struct ICPRequestEnvelope: Encodable {
     public let content: ICPRequestContent
     public let sender_pubkey: Data?
     public let sender_sig: Data?
+    public let sender_delegation: [ICPSignedDelegation]?
     
-    public init(content: ICPRequestContent, sender_pubkey: Data, sender_sig: Data) {
+    public init(content: ICPRequestContent, sender_pubkey: Data, sender_sig: Data, sender_delegation: [ICPSignedDelegation]? = nil) {
         self.content = content
         self.sender_pubkey = sender_pubkey
         self.sender_sig = sender_sig
+        self.sender_delegation = sender_delegation
     }
     
     public init(content: ICPRequestContent) {
         self.content = content
         self.sender_pubkey = nil
         self.sender_sig = nil
+        self.sender_delegation = nil
     }
     
     public func encode(to encoder: Encoder) throws {
-        enum Keys: String, CodingKey { case content, sender_pubkey, sender_sig }
+        enum Keys: String, CodingKey { case content, sender_pubkey, sender_sig, sender_delegation }
         var container = encoder.container(keyedBy: Keys.self)
         if let readStateContent = content as? ReadStateRequestContent {
             try container.encode(readStateContent, forKey: Keys.content)
@@ -35,6 +38,7 @@ public struct ICPRequestEnvelope: Encodable {
         }
         try container.encode(sender_pubkey, forKey: Keys.sender_pubkey)
         try container.encode(sender_sig, forKey: Keys.sender_sig)
+        try container.encode(sender_delegation, forKey: Keys.sender_delegation)
     }
     
     private enum ICPRequestEnvelopeEncodingError: Error {

--- a/Sources/IcpKit/Models/ICPDelegatedIdentity.swift
+++ b/Sources/IcpKit/Models/ICPDelegatedIdentity.swift
@@ -1,0 +1,162 @@
+//
+//  ICPDelegatedIdentity.swift
+//
+
+import Foundation
+import CryptoKit
+@preconcurrency import PotentASN1
+
+/// An identity that has been delegated the authority to authenticate as a different principal.
+/// Note: This type validates the delegation chain during initialization.
+public final class ICPDelegatedIdentity: ICPSigningPrincipal, ICPDelegationProvider, ICPDerPublicKeyProvider {
+    public enum Error: Swift.Error {
+        case invalidDerPublicKey
+        case unsupportedAlgorithm
+        case invalidSignature
+        case brokenChain
+        case signingKeyMismatch
+    }
+
+    private enum PublicKeyAlgorithm {
+        case secp256k1
+        case p256
+        case ed25519
+    }
+
+    private struct ParsedPublicKey {
+        let algorithm: PublicKeyAlgorithm
+        let keyBytes: Data
+    }
+
+    public let principal: ICPPrincipal
+    /// For this type, `rawPublicKey` is the DER-encoded public key.
+    public let rawPublicKey: Data
+    public let publicKeyDer: Data
+    public var delegationChain: [ICPSignedDelegation] {
+        let baseChain = (signingIdentity as? ICPDelegationProvider)?.delegationChain ?? []
+        return baseChain + chain
+    }
+
+    private let signingIdentity: ICPSigningPrincipal
+    private let chain: [ICPSignedDelegation]
+
+    /// Creates a delegated identity that signs using `to`, for the principal corresponding to `fromPublicKeyDer`.
+    ///
+    /// - Parameters:
+    ///   - fromPublicKeyDer: DER-encoded public key of the delegated-from principal.
+    ///   - to: The signing identity used to sign requests.
+    ///   - chain: Delegations connecting `fromPublicKeyDer` to `to.publicKey`, in order.
+    public init(fromPublicKeyDer: Data, to: ICPSigningPrincipal, chain: [ICPSignedDelegation]) throws {
+        try ICPDelegatedIdentity.validateChain(fromPublicKeyDer: fromPublicKeyDer, to: to, chain: chain)
+        self.publicKeyDer = fromPublicKeyDer
+        self.rawPublicKey = fromPublicKeyDer
+        self.principal = ICPCryptography.selfAuthenticatingPrincipal(derPublicKey: fromPublicKeyDer)
+        self.signingIdentity = to
+        self.chain = chain
+    }
+
+    /// Creates a delegated identity without validating the delegation chain.
+    public static func unchecked(fromPublicKeyDer: Data, to: ICPSigningPrincipal, chain: [ICPSignedDelegation]) -> ICPDelegatedIdentity {
+        ICPDelegatedIdentity(uncheckedFromPublicKeyDer: fromPublicKeyDer, to: to, chain: chain)
+    }
+
+    private init(uncheckedFromPublicKeyDer: Data, to: ICPSigningPrincipal, chain: [ICPSignedDelegation]) {
+        self.publicKeyDer = uncheckedFromPublicKeyDer
+        self.rawPublicKey = uncheckedFromPublicKeyDer
+        self.principal = ICPCryptography.selfAuthenticatingPrincipal(derPublicKey: uncheckedFromPublicKeyDer)
+        self.signingIdentity = to
+        self.chain = chain
+    }
+
+    public func sign(_ message: Data, domain: ICPDomainSeparator) async throws -> Data {
+        try await signingIdentity.sign(message, domain: domain)
+    }
+}
+
+private extension ICPDelegatedIdentity {
+    static let ecPublicKeyOid: [UInt64] = [1, 2, 840, 10045, 2, 1]
+    static let secp256k1Oid: [UInt64] = [1, 3, 132, 0, 10]
+    static let prime256v1Oid: [UInt64] = [1, 2, 840, 10045, 3, 1, 7]
+    static let ed25519Oid: [UInt64] = [1, 3, 101, 112]
+
+    static func validateChain(fromPublicKeyDer: Data, to: ICPSigningPrincipal, chain: [ICPSignedDelegation]) throws {
+        var lastVerifiedDer = fromPublicKeyDer
+        for signed in chain {
+            let parsedKey = try parseDerPublicKey(lastVerifiedDer)
+            let message = try signed.delegation.signable()
+            try verify(signature: signed.signature, message: message, with: parsedKey)
+            lastVerifiedDer = signed.delegation.pubkey
+        }
+
+        let signingKeyDer: Data
+        if let derProvider = to as? ICPDerPublicKeyProvider {
+            signingKeyDer = derProvider.publicKeyDer
+        } else {
+            signingKeyDer = try ICPCryptography.der(uncompressedEcPublicKey: to.rawPublicKey)
+        }
+
+        guard lastVerifiedDer == signingKeyDer else {
+            throw Error.signingKeyMismatch
+        }
+    }
+
+    private static func parseDerPublicKey(_ der: Data) throws -> ParsedPublicKey {
+        let values = try ASN1Serialization.asn1(fromDER: der)
+        guard let value = values.first,
+              case .sequence(let topLevel) = value,
+              topLevel.count >= 2,
+              case .sequence(let algorithmItems) = topLevel[0].absolute,
+              let bitString = topLevel[1].bitStringValue else {
+            throw Error.invalidDerPublicKey
+        }
+
+        guard let algorithmOid = algorithmItems.first?.objectIdentifierValue?.fields else {
+            throw Error.invalidDerPublicKey
+        }
+
+        if algorithmOid == ecPublicKeyOid {
+            guard algorithmItems.count >= 2,
+                  let curveOid = algorithmItems[1].objectIdentifierValue?.fields else {
+                throw Error.invalidDerPublicKey
+            }
+            if curveOid == secp256k1Oid {
+                return ParsedPublicKey(algorithm: .secp256k1, keyBytes: bitString.bytes)
+            }
+            if curveOid == prime256v1Oid {
+                return ParsedPublicKey(algorithm: .p256, keyBytes: bitString.bytes)
+            }
+            throw Error.unsupportedAlgorithm
+        }
+
+        if algorithmOid == ed25519Oid {
+            return ParsedPublicKey(algorithm: .ed25519, keyBytes: bitString.bytes)
+        }
+
+        throw Error.unsupportedAlgorithm
+    }
+
+    private static func verify(signature: Data, message: Data, with key: ParsedPublicKey) throws {
+        switch key.algorithm {
+        case .secp256k1:
+            let isValid = try ICPCryptography.verifySecp256k1(
+                signatureDER: signature,
+                message: message,
+                publicKeyUncompressed: key.keyBytes
+            )
+            guard isValid else { throw Error.invalidSignature }
+
+        case .p256:
+            let publicKey = try P256.Signing.PublicKey(x963Representation: key.keyBytes)
+            let signature = try P256.Signing.ECDSASignature(derRepresentation: signature)
+            guard publicKey.isValidSignature(signature, for: message) else {
+                throw Error.invalidSignature
+            }
+
+        case .ed25519:
+            let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: key.keyBytes)
+            guard publicKey.isValidSignature(signature, for: message) else {
+                throw Error.invalidSignature
+            }
+        }
+    }
+}

--- a/Sources/IcpKit/Models/ICPDelegation.swift
+++ b/Sources/IcpKit/Models/ICPDelegation.swift
@@ -1,0 +1,77 @@
+//
+//  ICPDelegation.swift
+//
+
+import Foundation
+import Candid
+
+/// A delegation from one key to another.
+/// If key A signs a delegation containing key B, then key B may be used to authenticate
+/// as key A's corresponding principal.
+public struct ICPDelegation: Codable, Equatable {
+    /// The delegated-to key (DER-encoded public key).
+    public let pubkey: Data
+    /// A nanosecond timestamp after which this delegation is no longer valid.
+    public let expiration: UInt64
+    /// If present, this delegation only applies to requests sent to one of these canisters.
+    public let targets: [ICPPrincipal]?
+
+    public init(pubkey: Data, expiration: UInt64, targets: [ICPPrincipal]? = nil) {
+        self.pubkey = pubkey
+        self.expiration = expiration
+        self.targets = targets
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case pubkey
+        case expiration
+        case targets
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.pubkey = try container.decode(Data.self, forKey: .pubkey)
+        self.expiration = try container.decode(UInt64.self, forKey: .expiration)
+        self.targets = try container.decodeIfPresent([ICPPrincipal].self, forKey: .targets)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(pubkey, forKey: .pubkey)
+        try container.encode(expiration, forKey: .expiration)
+        try container.encodeIfPresent(targets, forKey: .targets)
+    }
+
+    /// Returns the request-id hash of this delegation (used as the message for signing).
+    public func requestId() throws -> Data {
+        try OrderIndependentHasher.orderIndependentHash(self)
+    }
+
+    /// Returns the domain-separated signable bytes for this delegation.
+    /// Use this only if you are signing arbitrary bytes yourself (not via `ICPSigningPrincipal.sign`).
+    public func signable() throws -> Data {
+        let hash = try requestId()
+        return ICPDomainSeparator("ic-request-auth-delegation").domainSeparatedData(hash)
+    }
+}
+
+/// A delegation that has been signed by a principal.
+public struct ICPSignedDelegation: Codable, Equatable {
+    public let delegation: ICPDelegation
+    public let signature: Data
+
+    public init(delegation: ICPDelegation, signature: Data) {
+        self.delegation = delegation
+        self.signature = signature
+    }
+}
+
+/// Provides a chain of delegations to include in the request envelope.
+public protocol ICPDelegationProvider {
+    var delegationChain: [ICPSignedDelegation] { get }
+}
+
+/// Provides a DER-encoded public key.
+public protocol ICPDerPublicKeyProvider {
+    var publicKeyDer: Data { get }
+}

--- a/Sources/IcpKit/Models/ICPSigningPrincipal.swift
+++ b/Sources/IcpKit/Models/ICPSigningPrincipal.swift
@@ -13,3 +13,11 @@ public protocol ICPSigningPrincipal {
     /// All implementations of this method must ultimately call `ICPCryptography.ellipticSign` with the appropriate private key and return the result
     func sign(_ message: Data, domain: ICPDomainSeparator) async throws -> Data
 }
+
+public extension ICPSigningPrincipal {
+    /// Sign a delegation to let another key be used to authenticate as this principal.
+    func signDelegation(_ delegation: ICPDelegation) async throws -> Data {
+        let requestId = try delegation.requestId()
+        return try await sign(requestId, domain: "ic-request-auth-delegation")
+    }
+}

--- a/Tests/IcpKitTests/ICPDelegatedIdentityTests.swift
+++ b/Tests/IcpKitTests/ICPDelegatedIdentityTests.swift
@@ -1,0 +1,423 @@
+//
+//  ICPDelegatedIdentityTests.swift
+//
+
+import XCTest
+import CryptoKit
+import Security
+import secp256k1
+@testable import IcpKit
+@preconcurrency import PotentASN1
+
+final class ICPDelegatedIdentityTests: XCTestCase {
+    func testInitValidP256Chain() throws {
+        let fromKey = P256.Signing.PrivateKey()
+        let toKey = P256.Signing.PrivateKey()
+
+        let fromDer = try TestKeyDer.p256PublicKeyDer(fromKey.publicKey)
+        let toDer = try TestKeyDer.p256PublicKeyDer(toKey.publicKey)
+
+        let delegation = ICPDelegation(
+            pubkey: toDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = try TestKeyDer.signDelegation(delegation, with: fromKey)
+
+        let toIdentity = try P256SigningPrincipal(privateKey: toKey)
+        let delegated = try ICPDelegatedIdentity(
+            fromPublicKeyDer: fromDer,
+            to: toIdentity,
+            chain: [signed]
+        )
+
+        XCTAssertEqual(delegated.publicKeyDer, fromDer)
+        XCTAssertEqual(delegated.rawPublicKey, fromDer)
+        XCTAssertEqual(delegated.principal, ICPCryptography.selfAuthenticatingPrincipal(derPublicKey: fromDer))
+        XCTAssertEqual(delegated.delegationChain, [signed])
+    }
+
+    func testInitValidEd25519Chain() throws {
+        let fromKey = Curve25519.Signing.PrivateKey()
+        let toKey = Curve25519.Signing.PrivateKey()
+
+        let fromDer = try TestKeyDer.ed25519PublicKeyDer(fromKey.publicKey)
+        let toDer = try TestKeyDer.ed25519PublicKeyDer(toKey.publicKey)
+
+        let delegation = ICPDelegation(
+            pubkey: toDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = try TestKeyDer.signDelegation(delegation, with: fromKey)
+
+        let toIdentity = try Ed25519SigningPrincipal(privateKey: toKey)
+        let delegated = try ICPDelegatedIdentity(
+            fromPublicKeyDer: fromDer,
+            to: toIdentity,
+            chain: [signed]
+        )
+
+        XCTAssertEqual(delegated.publicKeyDer, fromDer)
+        XCTAssertEqual(delegated.delegationChain, [signed])
+    }
+
+    func testInitValidSecp256k1Chain() throws {
+        let fromKey = try TestSecp256k1.generatePrivateKey()
+        let toKey = try TestSecp256k1.generatePrivateKey()
+
+        let fromDer = try ICPCryptography.der(uncompressedEcPublicKey: fromKey.publicKeyUncompressed)
+        let toDer = try ICPCryptography.der(uncompressedEcPublicKey: toKey.publicKeyUncompressed)
+
+        let delegation = ICPDelegation(
+            pubkey: toDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = try TestSecp256k1.signDelegation(delegation, with: fromKey)
+
+        let toIdentity = try Secp256k1SigningPrincipal(privateKey: toKey)
+        let delegated = try ICPDelegatedIdentity(
+            fromPublicKeyDer: fromDer,
+            to: toIdentity,
+            chain: [signed]
+        )
+
+        XCTAssertEqual(delegated.publicKeyDer, fromDer)
+        XCTAssertEqual(delegated.delegationChain, [signed])
+    }
+
+    func testInitThrowsOnInvalidSignature() throws {
+        let fromKey = P256.Signing.PrivateKey()
+        let toKey = P256.Signing.PrivateKey()
+
+        let fromDer = try TestKeyDer.p256PublicKeyDer(fromKey.publicKey)
+        let toDer = try TestKeyDer.p256PublicKeyDer(toKey.publicKey)
+
+        let delegation = ICPDelegation(
+            pubkey: toDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = try TestKeyDer.signDelegation(delegation, with: toKey) // wrong signer
+
+        let toIdentity = try P256SigningPrincipal(privateKey: toKey)
+
+        XCTAssertThrowsError(
+            try ICPDelegatedIdentity(fromPublicKeyDer: fromDer, to: toIdentity, chain: [signed])
+        ) { error in
+            XCTAssertEqual(error as? ICPDelegatedIdentity.Error, .invalidSignature)
+        }
+    }
+
+    func testInitThrowsOnInvalidDerPublicKey() throws {
+        let toKey = P256.Signing.PrivateKey()
+        let toDer = try TestKeyDer.p256PublicKeyDer(toKey.publicKey)
+
+        let delegation = ICPDelegation(
+            pubkey: toDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = ICPSignedDelegation(delegation: delegation, signature: Data([0x01]))
+        let invalidDer = try PotentASN1.ASN1Serialization.der(from: .sequence([.integer(1)]))
+
+        let toIdentity = try P256SigningPrincipal(privateKey: toKey)
+
+        XCTAssertThrowsError(
+            try ICPDelegatedIdentity(fromPublicKeyDer: invalidDer, to: toIdentity, chain: [signed])
+        ) { error in
+            XCTAssertEqual(error as? ICPDelegatedIdentity.Error, .invalidDerPublicKey)
+        }
+    }
+
+    func testInitThrowsOnUnsupportedAlgorithm() throws {
+        let toKey = P256.Signing.PrivateKey()
+        let toDer = try TestKeyDer.p256PublicKeyDer(toKey.publicKey)
+
+        let delegation = ICPDelegation(
+            pubkey: toDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = ICPSignedDelegation(delegation: delegation, signature: Data([0x01]))
+
+        let unsupportedDer = try TestKeyDer.customDerPublicKey(
+            algorithmOid: [1, 2, 3, 4],
+            keyBytes: Data([0x04] + Array(repeating: 0x00, count: 64))
+        )
+
+        let toIdentity = try P256SigningPrincipal(privateKey: toKey)
+
+        XCTAssertThrowsError(
+            try ICPDelegatedIdentity(fromPublicKeyDer: unsupportedDer, to: toIdentity, chain: [signed])
+        ) { error in
+            XCTAssertEqual(error as? ICPDelegatedIdentity.Error, .unsupportedAlgorithm)
+        }
+    }
+
+    func testInitThrowsOnSigningKeyMismatch() throws {
+        let fromKey = P256.Signing.PrivateKey()
+        let toKey = P256.Signing.PrivateKey()
+        let otherKey = P256.Signing.PrivateKey()
+
+        let fromDer = try TestKeyDer.p256PublicKeyDer(fromKey.publicKey)
+        let otherDer = try TestKeyDer.p256PublicKeyDer(otherKey.publicKey)
+
+        let delegation = ICPDelegation(
+            pubkey: otherDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = try TestKeyDer.signDelegation(delegation, with: fromKey)
+
+        let toIdentity = try P256SigningPrincipal(privateKey: toKey)
+
+        XCTAssertThrowsError(
+            try ICPDelegatedIdentity(fromPublicKeyDer: fromDer, to: toIdentity, chain: [signed])
+        ) { error in
+            XCTAssertEqual(error as? ICPDelegatedIdentity.Error, .signingKeyMismatch)
+        }
+    }
+
+    func testDelegationChainAppendsBaseChain() throws {
+        let fromKey = P256.Signing.PrivateKey()
+        let toKey = P256.Signing.PrivateKey()
+
+        let fromDer = try TestKeyDer.p256PublicKeyDer(fromKey.publicKey)
+        let toDer = try TestKeyDer.p256PublicKeyDer(toKey.publicKey)
+
+        let delegation = ICPDelegation(
+            pubkey: toDer,
+            expiration: 1_000_000_000_000_000_000
+        )
+        let signed = try TestKeyDer.signDelegation(delegation, with: fromKey)
+
+        let baseDelegation = ICPDelegation(
+            pubkey: Data([0x01, 0x02]),
+            expiration: 1_000_000_000_000_000_000
+        )
+        let baseSigned = ICPSignedDelegation(delegation: baseDelegation, signature: Data([0x03]))
+
+        let toIdentity = try P256SigningPrincipal(privateKey: toKey, delegationChain: [baseSigned])
+        let delegated = try ICPDelegatedIdentity(
+            fromPublicKeyDer: fromDer,
+            to: toIdentity,
+            chain: [signed]
+        )
+
+        XCTAssertEqual(delegated.delegationChain, [baseSigned, signed])
+    }
+}
+
+private final class P256SigningPrincipal: ICPSigningPrincipal, ICPDerPublicKeyProvider, ICPDelegationProvider {
+    let principal: ICPPrincipal
+    let rawPublicKey: Data
+    let publicKeyDer: Data
+    let delegationChain: [ICPSignedDelegation]
+
+    private let privateKey: P256.Signing.PrivateKey
+
+    init(privateKey: P256.Signing.PrivateKey, delegationChain: [ICPSignedDelegation] = []) throws {
+        self.privateKey = privateKey
+        self.rawPublicKey = privateKey.publicKey.x963Representation
+        self.publicKeyDer = try TestKeyDer.p256PublicKeyDer(privateKey.publicKey)
+        self.principal = ICPCryptography.selfAuthenticatingPrincipal(derPublicKey: publicKeyDer)
+        self.delegationChain = delegationChain
+    }
+
+    func sign(_ message: Data, domain: ICPDomainSeparator) async throws -> Data {
+        let domainSeparated = domain.domainSeparatedData(message)
+        let signature = try privateKey.signature(for: domainSeparated)
+        return signature.derRepresentation
+    }
+}
+
+private final class Ed25519SigningPrincipal: ICPSigningPrincipal, ICPDerPublicKeyProvider, ICPDelegationProvider {
+    let principal: ICPPrincipal
+    let rawPublicKey: Data
+    let publicKeyDer: Data
+    let delegationChain: [ICPSignedDelegation] = []
+
+    private let privateKey: Curve25519.Signing.PrivateKey
+
+    init(privateKey: Curve25519.Signing.PrivateKey) throws {
+        self.privateKey = privateKey
+        self.rawPublicKey = privateKey.publicKey.rawRepresentation
+        self.publicKeyDer = try TestKeyDer.ed25519PublicKeyDer(privateKey.publicKey)
+        self.principal = ICPCryptography.selfAuthenticatingPrincipal(derPublicKey: publicKeyDer)
+    }
+
+    func sign(_ message: Data, domain: ICPDomainSeparator) async throws -> Data {
+        let domainSeparated = domain.domainSeparatedData(message)
+        return try privateKey.signature(for: domainSeparated)
+    }
+}
+
+private final class Secp256k1SigningPrincipal: ICPSigningPrincipal, ICPDerPublicKeyProvider, ICPDelegationProvider {
+    let principal: ICPPrincipal
+    let rawPublicKey: Data
+    let publicKeyDer: Data
+    let delegationChain: [ICPSignedDelegation] = []
+
+    private let privateKey: TestSecp256k1.PrivateKey
+
+    init(privateKey: TestSecp256k1.PrivateKey) throws {
+        self.privateKey = privateKey
+        self.rawPublicKey = privateKey.publicKeyUncompressed
+        self.publicKeyDer = try ICPCryptography.der(uncompressedEcPublicKey: rawPublicKey)
+        self.principal = ICPCryptography.selfAuthenticatingPrincipal(derPublicKey: publicKeyDer)
+    }
+
+    func sign(_ message: Data, domain: ICPDomainSeparator) async throws -> Data {
+        let domainSeparated = domain.domainSeparatedData(message)
+        return try TestSecp256k1.sign(message: domainSeparated, with: privateKey)
+    }
+}
+
+private enum TestKeyDer {
+    static let ecPublicKeyOid: [UInt64] = [1, 2, 840, 10045, 2, 1]
+    static let prime256v1Oid: [UInt64] = [1, 2, 840, 10045, 3, 1, 7]
+    static let ed25519Oid: [UInt64] = [1, 3, 101, 112]
+
+    static func p256PublicKeyDer(_ publicKey: P256.Signing.PublicKey) throws -> Data {
+        try PotentASN1.ASN1Serialization.der(from: .sequence([
+            .sequence([
+                .objectIdentifier(ecPublicKeyOid),
+                .objectIdentifier(prime256v1Oid)
+            ]),
+            .bitString(0, publicKey.x963Representation)
+        ]))
+    }
+
+    static func signDelegation(_ delegation: ICPDelegation, with key: P256.Signing.PrivateKey) throws -> ICPSignedDelegation {
+        let message = try delegation.signable()
+        let signature = try key.signature(for: message)
+        return ICPSignedDelegation(delegation: delegation, signature: signature.derRepresentation)
+    }
+
+    static func ed25519PublicKeyDer(_ publicKey: Curve25519.Signing.PublicKey) throws -> Data {
+        try PotentASN1.ASN1Serialization.der(from: .sequence([
+            .sequence([
+                .objectIdentifier(ed25519Oid)
+            ]),
+            .bitString(0, publicKey.rawRepresentation)
+        ]))
+    }
+
+    static func customDerPublicKey(algorithmOid: [UInt64], keyBytes: Data) throws -> Data {
+        try PotentASN1.ASN1Serialization.der(from: .sequence([
+            .sequence([
+                .objectIdentifier(algorithmOid)
+            ]),
+            .bitString(0, keyBytes)
+        ]))
+    }
+
+    static func signDelegation(_ delegation: ICPDelegation, with key: Curve25519.Signing.PrivateKey) throws -> ICPSignedDelegation {
+        let message = try delegation.signable()
+        let signature = try key.signature(for: message)
+        return ICPSignedDelegation(delegation: delegation, signature: signature)
+    }
+}
+
+private enum TestSecp256k1 {
+    struct PrivateKey {
+        let bytes: Data
+        let publicKeyUncompressed: Data
+    }
+
+    static func generatePrivateKey() throws -> PrivateKey {
+        let privateKey = try randomPrivateKey()
+        let publicKey = try derivePublicKey(from: privateKey)
+        return PrivateKey(bytes: privateKey, publicKeyUncompressed: publicKey)
+    }
+
+    static func signDelegation(_ delegation: ICPDelegation, with key: PrivateKey) throws -> ICPSignedDelegation {
+        let message = try delegation.signable()
+        let signature = try sign(message: message, with: key)
+        return ICPSignedDelegation(delegation: delegation, signature: signature)
+    }
+
+    static func sign(message: Data, with key: PrivateKey) throws -> Data {
+        let hash = ICPCryptography.sha256(message)
+        var signature = secp256k1_ecdsa_signature()
+        let status = key.bytes.withUnsafeBytes { keyBuffer -> Int32 in
+            hash.withUnsafeBytes { hashBuffer -> Int32 in
+                secp256k1_ecdsa_sign(
+                    secp256k1.Context.raw,
+                    &signature,
+                    hashBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    keyBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    nil,
+                    nil
+                )
+            }
+        }
+        guard status == 1 else {
+            throw Secp256k1Error.signFailed
+        }
+
+        var output = Data(count: 72)
+        var outputLen = output.count
+        let exportStatus = output.withUnsafeMutableBytes { outputBuffer -> Int32 in
+            secp256k1_ecdsa_signature_serialize_der(
+                secp256k1.Context.raw,
+                outputBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                &outputLen,
+                &signature
+            )
+        }
+        guard exportStatus == 1 else {
+            throw Secp256k1Error.signFailed
+        }
+
+        return output.prefix(outputLen)
+    }
+
+    private static func randomPrivateKey() throws -> Data {
+        var key = Data(count: 32)
+        var isValid = false
+        while !isValid {
+            let byteCount = key.count
+            _ = key.withUnsafeMutableBytes { buffer in
+                SecRandomCopyBytes(kSecRandomDefault, byteCount, buffer.baseAddress!)
+            }
+            isValid = key.withUnsafeBytes { buffer -> Bool in
+                secp256k1_ec_seckey_verify(
+                    secp256k1.Context.raw,
+                    buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
+                ) == 1
+            }
+        }
+        return key
+    }
+
+    private static func derivePublicKey(from privateKey: Data) throws -> Data {
+        var publicKey = secp256k1_pubkey()
+        let status = privateKey.withUnsafeBytes { buffer -> Int32 in
+            secp256k1_ec_pubkey_create(
+                secp256k1.Context.raw,
+                &publicKey,
+                buffer.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            )
+        }
+        guard status == 1 else {
+            throw Secp256k1Error.keyGenerationFailed
+        }
+
+        var output = Data(count: 65)
+        var outputLen = output.count
+        let exportStatus = output.withUnsafeMutableBytes { outputBuffer -> Int32 in
+            secp256k1_ec_pubkey_serialize(
+                secp256k1.Context.raw,
+                outputBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                &outputLen,
+                &publicKey,
+                UInt32(SECP256K1_EC_UNCOMPRESSED)
+            )
+        }
+        guard exportStatus == 1 else {
+            throw Secp256k1Error.keyGenerationFailed
+        }
+        return output.prefix(outputLen)
+    }
+
+    enum Secp256k1Error: Error {
+        case keyGenerationFailed
+        case signFailed
+    }
+}

--- a/Tests/IcpKitTests/ICPHttpRequestTests.swift
+++ b/Tests/IcpKitTests/ICPHttpRequestTests.swift
@@ -29,9 +29,45 @@ final class ICPHttpRequestTests: XCTestCase {
         XCTAssertEqual(decodedBody.content.request_type, "read_state")
         //XCTAssertEqual(decodedBody.content.sender, principal1.bytes)
         XCTAssertEqual(decodedBody.content.nonce.count, 32)
+        XCTAssertNil(decodedBody.sender_delegation)
         let expiry = Date(timeIntervalSince1970: TimeInterval(decodedBody.content.ingress_expiry / 1_000_000_000))
         XCTAssertLessThanOrEqual(Date.now.advanced(by: ICPRequestBuilder.defaultIngressExpirySeconds-1), expiry)
         XCTAssertGreaterThan(Date.now.advanced(by: ICPRequestBuilder.defaultIngressExpirySeconds+1), expiry)
+    }
+
+    func testRequestIncludesDelegation() async throws {
+        let delegation = ICPDelegation(
+            pubkey: Data([0xAA, 0xBB]),
+            expiration: 1_700_000_000_000_000_000,
+            targets: [ICPSystemCanisters.ledger]
+        )
+        let signedDelegation = ICPSignedDelegation(
+            delegation: delegation,
+            signature: Data([0xCC, 0xDD])
+        )
+
+        let mock = MockSigningPrincipal(
+            principal: ICPPrincipal(Data([0x01])),
+            publicKeyDer: Data([0x30, 0x01, 0x02]),
+            signature: Data([0x99, 0x88]),
+            delegationChain: [signedDelegation]
+        )
+
+        let readStateRequest = try await ICPRequest(
+            .readState(paths: []),
+            canister: ICPSystemCanisters.ledger,
+            sender: mock
+        )
+        let httpRequest = readStateRequest.httpRequest
+
+        let cborBody = httpRequest.body!
+        XCTAssertEqual(cborBody.prefix(3), Data([0xD9, 0xD9, 0xF7]))
+        let cborBodyWithoutTag = Data(cborBody.suffix(from: 3))
+        let decodedBody = try CBORDecoder.default.decode(ReadRequestDecodable.self, from: cborBodyWithoutTag)
+
+        XCTAssertEqual(decodedBody.sender_pubkey, mock.publicKeyDer)
+        XCTAssertEqual(decodedBody.sender_sig, mock.signature)
+        XCTAssertEqual(decodedBody.sender_delegation, mock.delegationChain)
     }
 }
 
@@ -39,6 +75,7 @@ private struct ReadRequestDecodable: Decodable {
     let content: Content
     let sender_pubkey: Data?
     let sender_sig: Data?
+    let sender_delegation: [ICPSignedDelegation]?
     
     struct Content: Decodable {
         let request_type: String
@@ -46,5 +83,25 @@ private struct ReadRequestDecodable: Decodable {
         let nonce: Data
         let ingress_expiry: Int
         let paths: [[Data]]
+    }
+}
+
+private struct MockSigningPrincipal: ICPSigningPrincipal, ICPDelegationProvider, ICPDerPublicKeyProvider {
+    let principal: ICPPrincipal
+    let rawPublicKey: Data
+    let publicKeyDer: Data
+    let signature: Data
+    let delegationChain: [ICPSignedDelegation]
+
+    init(principal: ICPPrincipal, publicKeyDer: Data, signature: Data, delegationChain: [ICPSignedDelegation]) {
+        self.principal = principal
+        self.rawPublicKey = Data([0x04])
+        self.publicKeyDer = publicKeyDer
+        self.signature = signature
+        self.delegationChain = delegationChain
+    }
+
+    func sign(_ message: Data, domain: ICPDomainSeparator) async throws -> Data {
+        signature
     }
 }


### PR DESCRIPTION
This PR introduces delegated identity support across the signing pipeline.

It adds `ICPDelegatedIdentity` and delegation models, supports DER-encoded public keys and delegation chains in request envelopes, and extends `ICPSigningPrincipal` with delegation signing.

Tests cover delegation validation, failure cases, and request envelope inclusion.

## Key Changes
- Added delegation models (`ICPDelegation`, `ICPSignedDelegation`) and provider protocols for delegation chains and DER public keys.
- Introduced `ICPDelegatedIdentity` with delegation-chain validation and signature verification for P256, Ed25519, and secp256k1.
- Extended request envelope/building to include `sender_delegation`, and added DER-based self-authenticating principal helper.
- Added secp256k1 signature verification utility.
- Expanded tests to cover delegation validation, failure cases, and request envelope inclusion.
